### PR TITLE
[FE / Feature] 문제 랭킹 페이지 구현

### DIFF
--- a/app/daily-problem/page.tsx
+++ b/app/daily-problem/page.tsx
@@ -1,8 +1,49 @@
+import Card from "@/components/home/card";
+import ComponentGrid from "@/components/home/component-grid";
+
 export default function ProblemRank() {
 
     return(
-        <>
-            오늘의 문제
-        </>
-    )
+        <div className="my-10 grid w-full max-w-screen-xl animate-fade-up grid-cols-1 gap-5 px-5 md:grid-cols-3 xl:px-0">
+        {features.map(({ title, description, demo, large }) => (
+            <Card
+                key={title}
+                title={title}
+                description={description}
+                demo={
+                    title === "Beautiful, reusable components" ? (
+                    <ComponentGrid />
+                    ) : (
+                    demo
+                    )
+                }
+                large={large}
+            />
+        ))}
+        </div>
+    );
 }
+
+const features = [
+  {
+    title: "Beautiful, reusable components",
+    description:
+      "Pre-built beautiful, a11y-first components, powered by [Tailwind CSS](https://tailwindcss.com/), [Radix UI](https://www.radix-ui.com/), and [Framer Motion](https://framer.com/motion)",
+    large: true,
+  },
+  {
+    title: "Hooks, utilities, and more",
+    description:
+      "Precedent offers a collection of hooks, utilities, and `@vercel/og`",
+    demo: (
+      <div className="grid grid-flow-col grid-rows-3 gap-10 p-10">
+        <span className="font-mono font-semibold">useIntersectionObserver</span>
+        <span className="font-mono font-semibold">useLocalStorage</span>
+        <span className="font-mono font-semibold">useScroll</span>
+        <span className="font-mono font-semibold">nFormatter</span>
+        <span className="font-mono font-semibold">capitalize</span>
+        <span className="font-mono font-semibold">truncate</span>
+      </div>
+    ),
+  },
+];

--- a/app/problem-rank/page.tsx
+++ b/app/problem-rank/page.tsx
@@ -1,49 +1,12 @@
-import Card from "@/components/home/card";
-import ComponentGrid from "@/components/home/component-grid";
+import ProblemRanking from "./problem-ranking-table";
 
 export default function ProblemRank() {
 
     return(
-        <div className="my-10 grid w-full max-w-screen-xl animate-fade-up grid-cols-1 gap-5 px-5 md:grid-cols-3 xl:px-0">
-        {features.map(({ title, description, demo, large }) => (
-            <Card
-                key={title}
-                title={title}
-                description={description}
-                demo={
-                    title === "Beautiful, reusable components" ? (
-                    <ComponentGrid />
-                    ) : (
-                    demo
-                    )
-                }
-                large={large}
-            />
-        ))}
-        </div>
+        <>
+          <div className="my-10 grid w-full max-w-screen-xl grid-cols-1 gap-5 px-5 md:grid-cols-3 xl:px-0 ">
+            <ProblemRanking/>
+          </div>
+        </>
     );
 }
-
-const features = [
-  {
-    title: "Beautiful, reusable components",
-    description:
-      "Pre-built beautiful, a11y-first components, powered by [Tailwind CSS](https://tailwindcss.com/), [Radix UI](https://www.radix-ui.com/), and [Framer Motion](https://framer.com/motion)",
-    large: true,
-  },
-  {
-    title: "Hooks, utilities, and more",
-    description:
-      "Precedent offers a collection of hooks, utilities, and `@vercel/og`",
-    demo: (
-      <div className="grid grid-flow-col grid-rows-3 gap-10 p-10">
-        <span className="font-mono font-semibold">useIntersectionObserver</span>
-        <span className="font-mono font-semibold">useLocalStorage</span>
-        <span className="font-mono font-semibold">useScroll</span>
-        <span className="font-mono font-semibold">nFormatter</span>
-        <span className="font-mono font-semibold">capitalize</span>
-        <span className="font-mono font-semibold">truncate</span>
-      </div>
-    ),
-  },
-];

--- a/app/problem-rank/problem-ranking-table.tsx
+++ b/app/problem-rank/problem-ranking-table.tsx
@@ -1,28 +1,30 @@
+import Link from "next/link";
+
 export default function ProblemRanking() {
 
     const dummy: { [key: number]: { problem_no: number, title: string, category: string[], solved_cnt: number} } = {
         1: {
-            problem_no: 13,
-            title: "임시 문제 제목1",
-            category: ["분류 1"],
+            problem_no: 5644,
+            title: "Coalescing Continents",
+            category: ["DFS"],
             solved_cnt: 13,
         },
         2: {
             problem_no: 1263,
-            title: "임시 문제 제목2",
-            category: ["분류 2", "분류 3"],
+            title: "시간 관리",
+            category: ["Brute Force", "DP"],
             solved_cnt: 163,
         },
         3: {
             problem_no: 13156,
-            title: "임시 문제 제목3",
-            category: ["분류 1", "분류 3"],
+            title: "Selling CPUs",
+            category: ["BFS", "DP"],
             solved_cnt: 123,
         },
         4: {
-            problem_no: 9193,
-            title: "임시 문제 제목4",
-            category: ["분류 4","분류 6"],
+            problem_no: 19193,
+            title: "Lines",
+            category: ["Greedy","Segment Tree"],
             solved_cnt: 113,
         },        
     };
@@ -34,7 +36,11 @@ export default function ProblemRanking() {
         return (
             <tr className="bg-white border-b dark:bg-gray-800 dark:border-gray-700" key={data.problem_no}>
                 <th scope="row" className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">{data.problem_no}</th>
-                <td className="px-6 py-4">{data.title}</td>
+                <td className="px-6 py-4">
+                    <Link href={`https://www.acmicpc.net/problem/${data.problem_no}`}>
+                        {data.title}
+                    </Link>
+                </td>
                 <td className="px-6 py-4">{data.category.join(", ")}</td>
                 <td className="px-6 py-4">{data.solved_cnt}</td>
             </tr>

--- a/app/problem-rank/problem-ranking-table.tsx
+++ b/app/problem-rank/problem-ranking-table.tsx
@@ -1,0 +1,90 @@
+export default function ProblemRanking() {
+
+    const dummy: { [key: number]: { problem_no: number, title: string, category: string[], solved_cnt: number} } = {
+        1: {
+            problem_no: 13,
+            title: "임시 문제 제목1",
+            category: ["분류 1"],
+            solved_cnt: 13,
+        },
+        2: {
+            problem_no: 1263,
+            title: "임시 문제 제목2",
+            category: ["분류 2", "분류 3"],
+            solved_cnt: 163,
+        },
+        3: {
+            problem_no: 13156,
+            title: "임시 문제 제목3",
+            category: ["분류 1", "분류 3"],
+            solved_cnt: 123,
+        },
+        4: {
+            problem_no: 9193,
+            title: "임시 문제 제목4",
+            category: ["분류 4","분류 6"],
+            solved_cnt: 113,
+        },        
+    };
+
+    const sortedData = Object.values(dummy).sort((a, b) => b.solved_cnt - a.solved_cnt);
+
+    const ProblemRating = ({ data }: { data: { problem_no: number, title: string, category: string[], solved_cnt: number } }) => {
+
+        return (
+            <tr className="bg-white border-b dark:bg-gray-800 dark:border-gray-700" key={data.problem_no}>
+                <th scope="row" className="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">{data.problem_no}</th>
+                <td className="px-6 py-4">{data.title}</td>
+                <td className="px-6 py-4">{data.category.join(", ")}</td>
+                <td className="px-6 py-4">{data.solved_cnt}</td>
+            </tr>
+        )
+    }
+
+    return (
+        <>
+            <div className="flex-col justify-around col-start-1 col-end-7 h-96 overflow-hidden rounded-xl border border-gray-200 bg-white shadow-md ">
+                <div className="animate-fade-up relative overflow-x-auto">
+                    <h2
+                        className="animate-fade-up bg-gradient-to-br from-black to-stone-500 bg-clip-text text-center font-display text-4xl font-bold tracking-[-0.02em] text-transparent opacity-0 drop-shadow-sm md:text-7xl md:leading-[5rem]"
+                        style={{ animationDelay: "0.15s", animationFillMode: "forwards" }}
+                    >
+                        {/* <Balancer> */}
+                        문제 랭킹
+                        {/* </Balancer> */}
+                    </h2>
+                    <br></br>
+                    <table className="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+                        <thead className="text-gray-700 uppercase bg-gray-50 dark:bg-gray-700 dark:text-gray-400">
+                            <tr>
+                                <th scope="col" className="px-6 py-3">
+                                    문제 번호
+                                </th>
+                                <th scope="col" className="px-6 py-3">
+                                    <div className="flex items-center">
+                                        문제 제목
+                                    </div>
+                                </th>
+                                <th scope="col" className="px-6 py-3">
+                                    <div className="flex items-center">
+                                        분류
+                                    </div>
+                                </th>
+                                <th scope="col" className="px-6 py-3">
+                                    <div className="flex items-center">
+                                        푼 사람 수
+                                    </div>
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {sortedData.map((data) => (
+                                <ProblemRating key={data.problem_no} data={data} />
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
![Untitled](https://user-images.githubusercontent.com/77713508/235852517-7fea86ee-edbc-4dd9-b75e-96b389f5ede0.gif)

<aside>
💡 문제 랭킹 페이지에 필요한 랭킹 테이블과 백준 페이지 연동

</aside>

- 이전에 구현된 weeklyRanking 컴포넌트를 활용하여 문제 랭킹 테이블 구현
    - 이 과정에서 불필요한 라이브러리의 주입 제거
    - 문제 제목에 next/link 컴포넌트를 활용하여 백준 사이트로의 연결

- 추가된 컴포넌트 요소들에 대한 자연스러운 fade-in 애니메이션 적용

## 디버깅 로그

> 추가할 만한 디버깅 사항이 없으므로 생략

close #5 